### PR TITLE
Add return color functionality

### DIFF
--- a/src/anagram_set.json
+++ b/src/anagram_set.json
@@ -1,0 +1,10 @@
+{
+    "sixLetterSet" : [
+        [
+            "canter",
+            "nectar",
+            "recant",
+            "trance"
+        ]
+    ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,8 @@ const returnColor = (word, wordSet) => {
             )
         }
         return result
-    } else {
-        return false
-    }
+    } 
+    return false
 }
 
 module.exports = { checkIfWord, returnColor }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,14 @@
 var checkWord = require('check-word')
 words = checkWord('en')
 
+var anagramSet = require('./anagram_set.json')
+
 const checkIfWord = function (word) {
     return words.check(word)
+}
+
+const returnColor = function (word) {
+    //pass
 }
 
 module.exports = { checkIfWord }

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,34 @@
-var checkWord = require('check-word')
-words = checkWord('en')
+const checkWord = require('check-word')
+const words = checkWord('en')
 
-var anagramSet = require('./anagram_set.json')
+//const anagramSet = require('./anagram_set.json')
 
-const checkIfWord = function (word) {
+const checkIfWord = (word) => {
     return words.check(word)
 }
 
-const returnColor = function (word) {
-    //pass
+const returnColor = (word, wordSet) => {
+    if (checkIfWord(word)) {
+        let result = '' // Green = G, Yellow = Y, Red = R
+        let charCounter = (w) => {
+            let count = {}
+            for (let c of w) {
+                count[c] = (count[c] || 0) + 1
+            }
+            return count
+        }
+        let wordCharCount = charCounter(word), 
+            wordSetCharCount = charCounter(wordSet[0])
+        for (let c of word) {
+            result += ((wordCharCount[c] && wordSetCharCount[c])
+                ? ((wordCharCount[c] == wordSetCharCount[c]) ? 'G' : 'Y') 
+                : 'R'
+            )
+        }
+        return result
+    } else {
+        return false
+    }
 }
 
-module.exports = { checkIfWord }
+module.exports = { checkIfWord, returnColor }

--- a/test/return_color_test.js
+++ b/test/return_color_test.js
@@ -1,0 +1,13 @@
+var assert = require('assert')
+
+var index = require('../src/index')
+var anagramSet = require('../src/anagram_set.json')
+
+describe('#returnColor()', function() {
+  it('should return a color combination if word is valid', function() {
+    assert.equal(index.returnColor('stairs', anagramSet['sixLetterSet'][0]), 'RGGRGR')
+  })
+  it('should return false if word is invalid', function() {
+    assert.equal(index.checkIfWord('abcdef'), false)
+  })
+})


### PR DESCRIPTION
Jira ticket: https://lipsumtext.atlassian.net/browse/LS-4

As requested, added a function that returns a corresponding color combination given a word and a word set.

Please note that the scope of the program only covers six-letter words (for now). 

Also deviated from the original requirement regarding flags (used G for green, Y for yellow, and R for red).